### PR TITLE
Remove left space on links with no icons

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -77,10 +77,10 @@ const styles = StyleSheet.create({
   icon: {
     width: 20,
     height: 20,
+    marginRight: 20,
     resizeMode: 'contain',
   },
   title: {
-    marginLeft: 20,
     color: 'white',
   },
 });


### PR DESCRIPTION
### Before
<img width="192" alt="screen shot 2018-07-05 at 12 03 57 pm" src="https://user-images.githubusercontent.com/8093376/42334718-0d5c3168-804c-11e8-9f8f-51a1d0854007.png">

### After
<img width="258" alt="screen shot 2018-07-05 at 12 03 18 pm" src="https://user-images.githubusercontent.com/8093376/42334717-0d1c17ea-804c-11e8-8bb0-93c62b1952f0.png">

